### PR TITLE
Couple of additional tests for clarity

### DIFF
--- a/jvm/src/test/scala/imp/BytecodeTest.scala
+++ b/jvm/src/test/scala/imp/BytecodeTest.scala
@@ -6,27 +6,36 @@ class BytecodeTest extends PropSpec with Matchers {
 
   val b = Decompile.decompile("imp.Methods")
 
-  property("incr2 = incr1") {
+  property("Invocation on instance summoned with imp[A] is equivalent to direct invocation on an implicit parameter") {
     b("incr2") shouldBe b("incr1")
   }
 
-  property("incr3 = incr1") {
+  property("Invocation on instance created from an apply method implemented using macro summon, is equivalent to invocation on an implicit parameter") {
     b("incr3") shouldBe b("incr1")
   }
 
-  property("incr4 > incr1") {
+  property("Invocation on imp[A], implicit parameter or apply with macro summon is less bytecode than implicitly[A]") {
     b("incr4").length should be > b("incr1").length
   }
 
-  property("incr5 > incr1") {
+  property("Invocation on imp[A], implicit parameter, or apply with macro summon is less bytecode than normal apply pattern, even with @inline final") {
     b("incr5").length should be > b("incr1").length
   }
 
-  property("withImp = withExplicitParam") {
+  property("Apply implemented with macro summon is less bytecode than Apply implemented with imp[A]") {
+    b("incr6").length should be > b("incr3").length
+  }
+
+  property("Apply implemented with imp[A] generates the same amount of bytecode as normal apply pattern") {
+    b("incr6").length shouldBe b("incr5").length
+  }
+
+  property("Summoning with imp[A] inside method generates the same bytecode as an explicit parameter") {
     b("withImp") shouldBe b("withExplicitParam")
   }
 
-  property("withImplicitly > withImp") {
+  property("Summoning with imp[A] generates less bytecode than summoning with implicitly[A]") {
     b("withImplicitly").length should be > b("withImp").length
   }
+
 }

--- a/jvm/src/test/scala/imp/Incr.scala
+++ b/jvm/src/test/scala/imp/Incr.scala
@@ -8,9 +8,12 @@ trait Incr[A] {
 }
 
 object Incr {
+
   def apply[A: Incr]: Incr[A] = macro summon[Incr[A]]
 
   @inline final def apply2[A](implicit ev: Incr[A]): Incr[A] = ev
+
+  @inline final def apply3[A: Incr]: Incr[A] = imp[Incr[A]]
 
   implicit object IntIncr extends Incr[Int] {
     def incr(n: Int): Int = n + 1

--- a/jvm/src/test/scala/imp/Methods.scala
+++ b/jvm/src/test/scala/imp/Methods.scala
@@ -14,7 +14,9 @@ class Methods {
   def incr1[A](a: A)(implicit ev: Incr[A]): A = ev.incr(a)
   def incr2[A: Incr](a: A): A = imp[Incr[A]].incr(a)
   def incr3[A: Incr](a: A): A = Incr[A].incr(a)
-  // these two have extra bytecode compared to the first 3
+
+  // these three have extra bytecode compared to the first 3
   def incr4[A: Incr](a: A): A = implicitly[Incr[A]].incr(a)
   def incr5[A: Incr](a: A): A = Incr.apply2[A].incr(a)
+  def incr6[A: Incr](a: A): A = Incr.apply3[A].incr(a)
 }


### PR DESCRIPTION
As part of looking at https://github.com/mpilquist/simulacrum/pull/49 I wanted to find out a bit more about the `imp` macro. 

In particular, I wanted to prove to myself that using `macro summon` for `apply` was better than using `imp[A]` for the `apply` implementation.

I was close to 100% confident on that anyway, but I wrote a couple of tests to make sure.

As part of doing that, I found the tests that had already been written very instructive, in the way that they tell a story by creating a baseline for comparison in a couple of the tests and then using that as a base to draw conclusions in the other tests.

I updated the descriptions of the tests to tell this story using the test descriptions in a more english language way, and also included the two extra tests I'd added for myself.

I thought this would be worth submitting as I certainly found the whole thing instructive and educational and I am hoping that these changes may also make the tests useful for others.
