### PR TITLE
Fix issue with cross testing for 2.10 and 2.11

### DIFF
--- a/jvm/src/test/scala-2.10/imp/Decompile.scala
+++ b/jvm/src/test/scala-2.10/imp/Decompile.scala
@@ -1,0 +1,5 @@
+package imp
+
+object Decompile extends DecompileBase {
+  val ClassPath = "jvm/target/scala-2.10/test-classes"
+}

--- a/jvm/src/test/scala-2.11/imp/Decompile.scala
+++ b/jvm/src/test/scala-2.11/imp/Decompile.scala
@@ -1,0 +1,5 @@
+package imp
+
+object Decompile extends DecompileBase {
+  val ClassPath = "jvm/target/scala-2.11/test-classes"
+}

--- a/jvm/src/test/scala/imp/Decompile.scala
+++ b/jvm/src/test/scala/imp/Decompile.scala
@@ -3,13 +3,13 @@ package imp
 import scala.collection.mutable.ArrayBuffer
 import scala.sys.process._
 
-object Decompile {
+trait DecompileBase {
 
   val Prototype = """^  public .+ ([^ ]+)\(.+\);$""".r
   val Line = """^    ( *[0-9]+.+)$""".r
   val Empty = """^ *$""".r
 
-  val ClassPath = "jvm/target/scala-2.11/test-classes"
+  def ClassPath: String
 
   def decompile(cls: String, cp: String = ClassPath): Map[String, String] = {
     val output = Seq("javap", "-c", "-classpath", cp, "imp.Methods").!!


### PR DESCRIPTION
The Decompile utility used in testing generated byte code, hardcodes the relative path to the generated scala 2.11 test classes. 

When building for scala 2.11 or when building for scala 2.10 after building for scala 2.11, the test executed without failure, however, the scala 2.10 test was actually looking at the scala 2.11 byte code (which may or may not be different).

However, when cross building, e.g. with +test command in sbt, the scala 2.10 code is tested first, which means that during clean followed by +test, the scala 2.10 test would fail, as the scala 2.11 output had not been produced yet.

This fix abstracts the Decompile utility to supply the appropriate class path to the test processing based on whether the test is for scala 2.10 or 2.11.

This is quite possibly related to #3, though I am not sure how to test if this fix results in resolving that issue too as I’m not sure how to run the release process locally - I'll look into this also.
