### PR TITLE
Add support for Scala 2.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,6 @@ TAGS
 .idea
 .idea/*
 .idea_modules
+.bloop
+.metals
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Magma[A])` parameter also.)
 
 ### Getting Imp
 
-Imp supports Scala 2.10, 2.11, 2.12, and 2.13.0-RC1. If you use SBT,
+Imp supports Scala 2.10, 2.11, 2.12, and 2.13. If you use SBT,
 you can include Imp via the following `build.sbt` snippets:
 
 ```scala

--- a/build.sbt
+++ b/build.sbt
@@ -4,10 +4,10 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 lazy val impSettings = Seq(
   organization := "org.spire-math",
   scalaVersion := crossScalaVersions.value.last,
-  crossScalaVersions := Seq("2.10.6", "2.11.12", "2.12.8", "2.13.0-RC1"),
+  crossScalaVersions := Seq("2.10.6", "2.11.12", "2.12.8", "2.13.0"),
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
-    "org.scalatest" %%% "scalatest" % "3.0.8-RC2" % "test"
+    "org.scalatest" %%% "scalatest" % "3.0.8" % "test"
   ),
   scalacOptions ++= Seq(
     "-deprecation",

--- a/jvm/src/test/scala-2.13.0-RC1/imp/Decompile.scala
+++ b/jvm/src/test/scala-2.13.0-RC1/imp/Decompile.scala
@@ -1,5 +1,0 @@
-package imp
-
-object Decompile extends DecompileBase {
-  val ClassPath = "jvm/target/scala-2.13.0-RC1/test-classes"
-}

--- a/jvm/src/test/scala-2.13/imp/Decompile.scala
+++ b/jvm/src/test/scala-2.13/imp/Decompile.scala
@@ -1,0 +1,5 @@
+package imp
+
+object Decompile extends DecompileBase {
+  val ClassPath = "jvm/target/scala-2.13/test-classes"
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"                  % "1.1.2")
 addSbtPlugin("com.github.gseitz"  % "sbt-release"              % "1.0.10")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.27")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.28")
 addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"             % "2.3")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")


### PR DESCRIPTION
I've also taken the liberty of adding Bloops and Metals entries to `.gitignore`.