### PR TITLE
Update to Scala JS 1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 lazy val impSettings = Seq(
   organization := "org.spire-math",
   scalaVersion := crossScalaVersions.value.last,
-  crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
+  crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.1"),
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
     "org.scalatest" %%% "scalatest" % "3.0.8" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val impSettings = Seq(
   crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.1"),
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
-    "org.scalatest" %%% "scalatest" % "3.0.8" % "test"
+    "org.scalatest" %%% "scalatest" % "3.1.1" % "test"
   ),
   scalacOptions ++= Seq(
     "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 lazy val impSettings = Seq(
   organization := "org.spire-math",
   scalaVersion := crossScalaVersions.value.last,
-  crossScalaVersions := Seq("2.10.6", "2.11.12", "2.12.8", "2.13.0"),
+  crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
     "org.scalatest" %%% "scalatest" % "3.0.8" % "test"

--- a/jvm/src/test/scala/imp/BytecodeTest.scala
+++ b/jvm/src/test/scala/imp/BytecodeTest.scala
@@ -1,8 +1,9 @@
 package imp
 
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 
-class BytecodeTest extends PropSpec with Matchers {
+class BytecodeTest extends AnyPropSpec with Matchers {
 
   val b = Decompile.decompile("imp.Methods")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"                  % "1.1.2")
 addSbtPlugin("com.github.gseitz"  % "sbt-release"              % "1.0.10")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.28")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.0.0")
 addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"             % "2.3")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")


### PR DESCRIPTION
On top of upgrading Scala JS, this PR will:
* drop support for 2.10 (not supported by Scala JS 1.0.0)
* upgrade to Scala 2.13.1 because why not?
* upgrade to scalatest 3.1.1 because previous versions aren't compatible with Scala JS 1.0.0